### PR TITLE
changes made to support simulated linnstrument

### DIFF
--- a/src/synthv1.lv2/synthv1.ttl
+++ b/src/synthv1.lv2/synthv1.ttl
@@ -591,7 +591,7 @@
 		lv2:name "DEF1 Pitchbend" ;
 		lv2:default 0.2 ;
 		lv2:minimum 0.0 ;
-		lv2:maximum 1.0 ;
+		lv2:maximum 4.0 ;
 		lv2pg:group synthv1_lv2:G106_DEF1 ;
 	], [
 		a lv2:InputPort, lv2:ControlPort ;
@@ -1164,7 +1164,7 @@
 		lv2:name "DEF2 Pitchbend" ;
 		lv2:default 0.2 ;
 		lv2:minimum 0.0 ;
-		lv2:maximum 1.0 ;
+		lv2:maximum 4.0 ;
 		lv2pg:group synthv1_lv2:G206_DEF2 ;
 	], [
 		a lv2:InputPort, lv2:ControlPort ;

--- a/src/synthv1_param.cpp
+++ b/src/synthv1_param.cpp
@@ -102,7 +102,7 @@ struct ParamInfo {
 	{ "OUT1_FXSEND",   PARAM_FLOAT,   1.0f,   0.0f,   1.0f }, // OUT1 FX Send
 	{ "OUT1_VOLUME",   PARAM_FLOAT,   0.5f,   0.0f,   1.0f }, // OUT1 Volume
 
-	{ "DEF1_PITCHBEND",PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF1 Pitchbend
+	{ "DEF1_PITCHBEND",PARAM_FLOAT,   4.0f,   0.0f,   4.0f }, // DEF1 Pitchbend
 	{ "DEF1_MODWHEEL", PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF1 Modwheel
 	{ "DEF1_PRESSURE", PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF1 Pressure
 	{ "DEF1_VELOCITY", PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF1 Velocity
@@ -163,7 +163,7 @@ struct ParamInfo {
 	{ "OUT2_FXSEND",   PARAM_FLOAT,   1.0f,   0.0f,   1.0f }, // OUT2 FX Send
 	{ "OUT2_VOLUME",   PARAM_FLOAT,   0.5f,   0.0f,   1.0f }, // OUT2 Volume
 
-	{ "DEF2_PITCHBEND",PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF2 Pitchbend
+	{ "DEF2_PITCHBEND",PARAM_FLOAT,   4.0f,   0.0f,   4.0f }, // DEF2 Pitchbend
 	{ "DEF2_MODWHEEL", PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF2 Modwheel
 	{ "DEF2_PRESSURE", PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF2 Pressure
 	{ "DEF2_VELOCITY", PARAM_FLOAT,   0.2f,   0.0f,   1.0f }, // DEF2 Velocity

--- a/src/synthv1widget.cpp
+++ b/src/synthv1widget.cpp
@@ -256,6 +256,12 @@ synthv1widget::synthv1widget ( QWidget *pParent, Qt::WindowFlags wflags )
 	m_ui.Lfo2VolumeKnob->setMinimum(-1.0f);
 	m_ui.Lfo2VolumeKnob->setMaximum(+1.0f);
 
+    // added by scotty to try to support linnstruments need for bigger bend range
+    m_ui.Def1PitchbendKnob->setMinimum(0.0f);
+    m_ui.Def1PitchbendKnob->setMaximum(+4.0f);
+    m_ui.Def2PitchbendKnob->setMinimum(0.0f);
+    m_ui.Def2PitchbendKnob->setMaximum(+4.0f);
+
 
 	// Channel filters
 	QStringList channels;


### PR DESCRIPTION
I’m not sure you or others would find a need for this, but I created a patch for your synthv1 to expand pitchbend range from 0 – 100.0 to 0 – 400.0.  I needed this range to support the use of a PME midi driving device called sensel.com Morph that is in this case setup as a simulator of a Linnstrument.  I could not find any alternative at the time to get around the limited pitchbend range of the synthv1.  This added range makes it possible to drag a note (pitchbend) in the same distance across  the template as is setup to lift your finger and play that same note.  As there are very few PME supported synths presently available on the linux platform to allow PME instruments to play out of the box, I saw your synthv1 as low hanging fruit with a very small change to add your instrument to the list.   I’m not sure that this patch change is the final solution but it works for me when I set it to 400.  You might note on how the Surge synth is setup that allows a wider range pitchbend that also works with the Sensel Morphs present setup.  I’m also not sure if a real Linnstrument would or wouldn’t work in some manner of configuration with the present synthv1 setup as I don’t own one to verify.  I also didn’t research to see if the other synths in your collection could also make use of a change like this.   In any case I have put the patch on my github account for you and others to see and make use of as you decide.  Thanks for the wonderful work you have done.  Keep it up,  we love you for it.