### PR TITLE
src/CMakeLists: Fix filename typo of manifest.ttl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,7 +191,7 @@ if (CONFIG_LV2)
       RENAME ${PROJECT_NAME}.dll
       DESTINATION ${CONFIG_LV2DIR}/${PROJECT_NAME}.lv2)
     install (FILES ${PROJECT_NAME}.lv2/manifest-win32.ttl
-      RENAME manifest.dll
+      RENAME manifest.ttl
       DESTINATION ${CONFIG_LV2DIR}/${PROJECT_NAME}.lv2)
     install (FILES ${PROJECT_NAME}.lv2/${PROJECT_NAME}.ttl
       DESTINATION ${CONFIG_LV2DIR}/${PROJECT_NAME}.lv2)


### PR DESCRIPTION
NOTE: Typo also appears in other Vee-One products.