### PR TITLE
Fix build on systems with new-style LV2 include directories.

### DIFF
--- a/src/synthv1_lv2.cpp
+++ b/src/synthv1_lv2.cpp
@@ -26,6 +26,21 @@
 #include "synthv1_programs.h"
 #include "synthv1_controls.h"
 
+#if __has_include (<lv2/core/lv2.h>)
+// new versions of LV2 use different location for headers
+#include "lv2/midi/midi.h"
+#include "lv2/time/time.h"
+#include "lv2/atom/util.h"
+
+#include "lv2/state/state.h"
+
+#include "lv2/options/options.h"
+#include "lv2/buf-size/buf-size.h"
+
+#ifdef CONFIG_LV2_PATCH
+#include "lv2/patch/patch.h"
+#endif
+#else
 #include "lv2/lv2plug.in/ns/ext/midi/midi.h"
 #include "lv2/lv2plug.in/ns/ext/time/time.h"
 #include "lv2/lv2plug.in/ns/ext/atom/util.h"
@@ -37,6 +52,7 @@
 
 #ifdef CONFIG_LV2_PATCH
 #include "lv2/lv2plug.in/ns/ext/patch/patch.h"
+#endif
 #endif
 
 #ifndef CONFIG_LV2_ATOM_FORGE_OBJECT

--- a/src/synthv1_lv2.h
+++ b/src/synthv1_lv2.h
@@ -24,11 +24,20 @@
 
 #include "synthv1.h"
 
+#if __has_include (<lv2/core/lv2.h>)
+// new versions of LV2 use different location for headers
+#include "lv2/urid/urid.h"
+#include "lv2/atom/atom.h"
+#include "lv2/atom/forge.h"
+
+#include "lv2/worker/worker.h"
+#else
 #include "lv2/lv2plug.in/ns/ext/urid/urid.h"
 #include "lv2/lv2plug.in/ns/ext/atom/atom.h"
 #include "lv2/lv2plug.in/ns/ext/atom/forge.h"
 
 #include "lv2/lv2plug.in/ns/ext/worker/worker.h"
+#endif
 
 #define SYNTHV1_LV2_URI "http://synthv1.sourceforge.net/lv2"
 #define SYNTHV1_LV2_PREFIX SYNTHV1_LV2_URI "#"

--- a/src/synthv1_lv2ui.cpp
+++ b/src/synthv1_lv2ui.cpp
@@ -22,7 +22,12 @@
 #include "synthv1_lv2ui.h"
 #include "synthv1_lv2.h"
 
+#if __has_include (<lv2/core/lv2.h>)
+// new versions of LV2 use different location for headers
+#include "lv2/instance-access/instance-access.h"
+#else
 #include "lv2/lv2plug.in/ns/ext/instance-access/instance-access.h"
+#endif
 
 #include <synthv1widget_lv2.h>
 

--- a/src/synthv1_lv2ui.h
+++ b/src/synthv1_lv2ui.h
@@ -24,7 +24,12 @@
 
 #include "synthv1_ui.h"
 
+#if __has_include (<lv2/core/lv2.h>)
+// new versions of LV2 use different location for headers
+#include "lv2/ui/ui.h"
+#else
 #include "lv2/lv2plug.in/ns/extensions/ui/ui.h"
+#endif
 
 
 #define SYNTHV1_LV2UI_URI SYNTHV1_LV2_PREFIX "ui"


### PR DESCRIPTION
I've been trying to build synthv1 from git on my system, which failed due to not finding the lv2 headers. I'm using kxstudio, so the lv2-dev package is
```
Package: lv2-dev
Version: 6:1.18.10-1kxstudio2
Maintainer: falkTX <falktx@falktx.com>
```
I've fixed this for synthv1 here, note that this is likely to cause problems in your other releases that include lv2 headers.