### PR TITLE
NSM keys in .desktop file

### DIFF
--- a/src/appdata/org.rncbc.synthv1.desktop
+++ b/src/appdata/org.rncbc.synthv1.desktop
@@ -14,3 +14,5 @@ Type=Application
 StartupWMClass=synthv1_jack
 X-Window-Icon=synthv1
 X-SuSE-translate=true
+X-NSM-Capable=true
+X-NSM-Exec=synthv1_jack


### PR DESCRIPTION
X-NSM-Capable=true
X-NSM-Exec=synthv1_jack

The second one sets the exec name to use when under NSM. Shouldn't be strictly needed as synthv1_jack is the default as far as I can see, but can't do harm either. 